### PR TITLE
Add some resource name checks using ArmApiControl

### DIFF
--- a/src/Saas.Deployment/Saas.Deployment.Root/createUiDefinition.json
+++ b/src/Saas.Deployment/Saas.Deployment.Root/createUiDefinition.json
@@ -33,14 +33,6 @@
                                 {
                                     "regex": "^[a-z0-9]{3,12}$",
                                     "message": "Only alphanumeric characters are allowed, and the value must be 3-12 characters long."
-                                },
-                                {
-                                    "isValid": "[not(equals(steps('saasSettings').nameApiOnboarding.nameAvailable, false))]",
-                                    "message": "[concat('This SaaS prefix, environment, and instance combination is unavailable: ', concat('api-onboarding-',steps('saasSettings').saasProviderName,'-',steps('saasSettings').saasEnvironment,'-',steps('saasSettings').saasInstanceNumber))]"
-                                },
-                                {
-                                    "isValid": "[not(equals(steps('saasSettings').nameApiProvider.nameAvailable, false))]",
-                                    "message": "[concat('This SaaS prefix, environment, and instance combination is unavailable: ', concat('app-',steps('saasSettings').saasProviderName,'-',steps('saasSettings').saasEnvironment,'-',steps('saasSettings').saasInstanceNumber))]"
                                 }
                             ]
                         },
@@ -88,6 +80,14 @@
                                 {
                                     "regex": "^[0-9]{3,3}$",
                                     "message": "Only alphanumeric characters are allowed, and the value must be 3 characters long."
+                                },
+                                {
+                                    "isValid": "[not(equals(steps('saasSettings').nameApiOnboarding.nameAvailable, false))]",
+                                    "message": "[concat('Onboarding API Web App with this name is not available: ', concat('api-onboarding-',steps('saasSettings').saasProviderName,'-',steps('saasSettings').saasEnvironment,'-',steps('saasSettings').saasInstanceNumber))]"
+                                },
+                                {
+                                    "isValid": "[not(equals(steps('saasSettings').nameApiProvider.nameAvailable, false))]",
+                                    "message": "[concat('Provider Web App with this name is not available: ', concat('app-',steps('saasSettings').saasProviderName,'-',steps('saasSettings').saasEnvironment,'-',steps('saasSettings').saasInstanceNumber))]"
                                 }
                             ]
                         },
@@ -207,7 +207,7 @@
                                 },
                                 {
                                     "isValid": "[not(equals(steps('sqlSettings').nameApi.available, false))]",
-                                    "message": "[concat('This Azure SQL server name is unavailable: ', steps('sqlSettings').sqlServerName)]"
+                                    "message": "[concat('Azure SQL server name with this name is not available: ', steps('sqlSettings').sqlServerName)]"
                                 }
                             ]
                         },


### PR DESCRIPTION
Modified createUiDefinition.json to include sample resource name validation using [ArmApiControl](https://docs.microsoft.com/en-us/azure/azure-resource-manager/managed-applications/microsoft-solutions-armapicontrol)
* Provider Web App
* Onboarding Web App
* Azure SQL Server

Unfortunately, Cosmos DB account name cannot be validated the same way since the [Check Name Exists API for Cosmos DB RP](https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/check-name-exists) is using HEAD call and returns 404 when name is available. ArmApiControl can only issue GET and POST calls and requires 200 status code with JSON response.

Here is how validation looks if SaaS Provider (i.e., prefix name) results in an already existing name.
![image](https://user-images.githubusercontent.com/1821568/136304950-61bccdc0-f1c1-4c07-a2f5-de9b723169f1.png)

Prior to merging in you can pre-test the UI definition using this URL pointing to my branch https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-saas%2Fmain%2Fsrc%2FSaas.Deployment%2FSaas.Deployment.Root%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Farsenvlad%2Fazure-saas%2Farsenv-uivalidations%2Fsrc%2FSaas.Deployment%2FSaas.Deployment.Root%2FcreateUiDefinition.json
