### PR TITLE
Added JWT/AAD Auth and Certificate based auth

### DIFF
--- a/src/Saas.Permissions/Saas.Permissions.Api/Controllers/CustomClaimsController.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Controllers/CustomClaimsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authentication.Certificate;
+using Microsoft.AspNetCore.Authorization;
 using Saas.Permissions.Api.Interfaces;
 using Saas.Permissions.Api.Models;
 
@@ -7,7 +8,8 @@ namespace Saas.Permissions.Api.Controllers;
 [Route("api/[controller]")]
 
 [ApiController]
-[Authorize]
+// Specify that this controller should use Certificate Based Auth. Certificate auth is required for fetching custom claims from B2C. 
+[Authorize(AuthenticationSchemes = CertificateAuthenticationDefaults.AuthenticationScheme)]
 public class CustomClaimsController : ControllerBase
 {
     private readonly IPermissionsService _permissionsService;

--- a/src/Saas.Permissions/Saas.Permissions.Api/Controllers/CustomClaimsController.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Controllers/CustomClaimsController.cs
@@ -1,4 +1,5 @@
-﻿using Saas.Permissions.Api.Interfaces;
+﻿using Microsoft.AspNetCore.Authorization;
+using Saas.Permissions.Api.Interfaces;
 using Saas.Permissions.Api.Models;
 
 namespace Saas.Permissions.Api.Controllers;
@@ -6,6 +7,7 @@ namespace Saas.Permissions.Api.Controllers;
 [Route("api/[controller]")]
 
 [ApiController]
+[Authorize]
 public class CustomClaimsController : ControllerBase
 {
     private readonly IPermissionsService _permissionsService;

--- a/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
@@ -1,4 +1,6 @@
-﻿using Saas.Permissions.Api.Exceptions;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Identity.Web.Resource;
+using Saas.Permissions.Api.Exceptions;
 using Saas.Permissions.Api.Interfaces;
 using System.Net;
 
@@ -6,6 +8,8 @@ namespace Saas.Permissions.Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
+[RequiredScope("access_as_user_via_admin_api")]
 public class PermissionsController : ControllerBase
 {
     private readonly IPermissionsService _permissionsService;

--- a/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
@@ -24,7 +24,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
+    [RequiredScope(new[] { "permissions.read", "permissions.write" })]
     [Route("GetTenantUsers")]
     public async Task<ICollection<string>> GetTenantUsers(string tenantId)
     {
@@ -36,7 +36,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
+    [RequiredScope(new[] { "permissions.read", "permissions.write" })]
     [Route("GetUserPermissionsForTenant")]
     public async Task<ICollection<string>> GetUserPermissionsForTenant(string tenantId, string userId)
     {
@@ -49,7 +49,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequiredScope("write_via_admin_api")]
+    [RequiredScope("permissions.write")]
     [Route("AddUserPermissionsToTenant")]
     public async Task<IActionResult> AddUserPermissionsToTenant(string tenantId, string userId, string[] permissions)
     {
@@ -71,7 +71,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequiredScope("write_via_admin_api")]
+    [RequiredScope("permissions.write")]
     [Route("RemoveUserPermissionsFromTenant")]
     public async Task<IActionResult> RemoveUserPermissionsFromTenant(string tenantId, string userId, string[] permissions)
     {
@@ -91,7 +91,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
+    [RequiredScope(new[] { "permissions.read", "permissions.write" })]
     [Route("GetTenantsForUser")]
     public async Task<ICollection<string>> GetTenantsForUser(string userId, string? filter)
     {

--- a/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Controllers/PermissionsController.cs
@@ -9,7 +9,6 @@ namespace Saas.Permissions.Api.Controllers;
 [Route("api/[controller]")]
 [ApiController]
 [Authorize]
-[RequiredScope("access_as_user_via_admin_api")]
 public class PermissionsController : ControllerBase
 {
     private readonly IPermissionsService _permissionsService;
@@ -25,6 +24,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
     [Route("GetTenantUsers")]
     public async Task<ICollection<string>> GetTenantUsers(string tenantId)
     {
@@ -36,6 +36,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
     [Route("GetUserPermissionsForTenant")]
     public async Task<ICollection<string>> GetUserPermissionsForTenant(string tenantId, string userId)
     {
@@ -48,6 +49,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequiredScope("write_via_admin_api")]
     [Route("AddUserPermissionsToTenant")]
     public async Task<IActionResult> AddUserPermissionsToTenant(string tenantId, string userId, string[] permissions)
     {
@@ -69,6 +71,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequiredScope("write_via_admin_api")]
     [Route("RemoveUserPermissionsFromTenant")]
     public async Task<IActionResult> RemoveUserPermissionsFromTenant(string tenantId, string userId, string[] permissions)
     {
@@ -88,6 +91,7 @@ public class PermissionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequiredScope(new[] { "read_via_admin_api", "write_via_admin_api" })]
     [Route("GetTenantsForUser")]
     public async Task<ICollection<string>> GetTenantsForUser(string userId, string? filter)
     {

--- a/src/Saas.Permissions/Saas.Permissions.Api/Interfaces/ICertificateValidationService.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Interfaces/ICertificateValidationService.cs
@@ -1,0 +1,7 @@
+﻿namespace Saas.Permissions.Api.Interfaces;
+using System.Security.Cryptography.X509Certificates;
+
+public interface ICertificateValidationService
+{
+    public bool ValidateCertificate(X509Certificate2 clientCertificate);
+}

--- a/src/Saas.Permissions/Saas.Permissions.Api/Models/AppSettings/AppSettings.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Models/AppSettings/AppSettings.cs
@@ -2,5 +2,5 @@
 
 public class AppSettings
 {
-    public string SelfSignedCertThumbprint { get; set; }
+    public string SelfSignedCertThumbprint { get; set; } = string.Empty;
 }

--- a/src/Saas.Permissions/Saas.Permissions.Api/Models/AppSettings/AppSettings.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Models/AppSettings/AppSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace Saas.Permissions.Api.Models.AppSettings;
+
+public class AppSettings
+{
+    public string SelfSignedCertThumbprint { get; set; }
+}

--- a/src/Saas.Permissions/Saas.Permissions.Api/Program.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Program.cs
@@ -3,11 +3,15 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 using Saas.Permissions.Api.Data;
 using Saas.Permissions.Api.Interfaces;
+using Saas.Permissions.Api.Models.AppSettings;
 using Saas.Permissions.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
+// Add options using options pattern : https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-6.0
+builder.Services.Configure<AppSettings>(builder.Configuration.GetSection(nameof(AppSettings)));
+
+
 // Add services to the container.
 
 builder.Services.AddControllers();

--- a/src/Saas.Permissions/Saas.Permissions.Api/Program.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Identity.Web;
 using Saas.Permissions.Api.Data;
 using Saas.Permissions.Api.Interfaces;
 using Saas.Permissions.Api.Services;
@@ -18,6 +20,14 @@ builder.Services.AddDbContext<PermissionsContext>(options =>
 
 builder.Services.AddScoped<IPermissionsService, PermissionsService>();
 
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApi(options =>
+    {
+        builder.Configuration.Bind("AzureAdB2C", options);
+        options.TokenValidationParameters.NameClaimType = "name";
+    },
+    options => { builder.Configuration.Bind("AzureAdB2C", options); });
+
 var app = builder.Build();
 app.ConfigureDatabase();
 
@@ -28,6 +38,7 @@ app.ConfigureDatabase();
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/src/Saas.Permissions/Saas.Permissions.Api/Saas.Permissions.Api.csproj
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Saas.Permissions.Api.csproj
@@ -7,12 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.23.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>

--- a/src/Saas.Permissions/Saas.Permissions.Api/Saas.Permissions.Api.csproj
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Saas.Permissions.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="6.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />

--- a/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Configuration;
+using Saas.Permissions.Api.Interfaces;
+using System.Security.Cryptography.X509Certificates;
+namespace Saas.Permissions.Api.Services;
+
+public class CertificateValidationService : ICertificateValidationService
+{
+    private readonly IConfiguration _config;
+    public CertificateValidationService(IConfiguration config)
+    {
+        _config = config;
+    }
+    public bool ValidateCertificate(X509Certificate2 clientCertificate)
+    {
+        // Don't hardcode passwords in production code.
+        // Use a certificate thumbprint or Azure Key Vault.
+        var expectedCertificateThumbPrint = _config.GetValue<string>("SelfSignedCertThumbprint");
+
+        return clientCertificate.Thumbprint == expectedCertificateThumbPrint;
+    }
+}

--- a/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
@@ -1,14 +1,16 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Saas.Permissions.Api.Interfaces;
+using Saas.Permissions.Api.Models.AppSettings;
 using System.Security.Cryptography.X509Certificates;
 namespace Saas.Permissions.Api.Services;
 
 public class CertificateValidationService : ICertificateValidationService
 {
-    private readonly IConfiguration _config;
-    public CertificateValidationService(IConfiguration config)
+    private readonly AppSettings _appSettings;
+    public CertificateValidationService(IOptions<AppSettings> appSettings)
     {
-        _config = config;
+        _appSettings = appSettings.Value;
     }
     public bool ValidateCertificate(X509Certificate2 clientCertificate)
     {
@@ -17,7 +19,7 @@ public class CertificateValidationService : ICertificateValidationService
 
         // Do not check your certificate thumbprint into your git repository.
         // Another option would be to load in your certificate thumbprint from azure keyvault.
-        var expectedCertificateThumbPrint = _config.GetValue<string>("SelfSignedCertThumbprint");
+        var expectedCertificateThumbPrint = _appSettings.SelfSignedCertThumbprint;
 
         return clientCertificate.Thumbprint == expectedCertificateThumbPrint;
     }

--- a/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
+++ b/src/Saas.Permissions/Saas.Permissions.Api/Services/CertificateValidationService.cs
@@ -12,8 +12,11 @@ public class CertificateValidationService : ICertificateValidationService
     }
     public bool ValidateCertificate(X509Certificate2 clientCertificate)
     {
-        // Don't hardcode passwords in production code.
-        // Use a certificate thumbprint or Azure Key Vault.
+        // Insert any other custom certificate validation logic here
+
+
+        // Do not check your certificate thumbprint into your git repository.
+        // Another option would be to load in your certificate thumbprint from azure keyvault.
         var expectedCertificateThumbPrint = _config.GetValue<string>("SelfSignedCertThumbprint");
 
         return clientCertificate.Thumbprint == expectedCertificateThumbPrint;

--- a/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
+++ b/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
@@ -13,6 +13,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "SelfSignedCertThumbprint": "thumbprinthere",
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "PermissionsContext": "Server=(localdb)\\mssqllocaldb;Database=Saas.Permissions.Sql;Trusted_Connection=True;MultipleActiveResultSets=true"

--- a/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
+++ b/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
@@ -1,4 +1,12 @@
 {
+  "AzureAdB2C": {
+    "Instance": "https://asdkdev.b2clogin.com",
+    "ClientId": "e93c92d5-dfe8-4589-8fd8-7373816fa7e3",
+    "Domain": "asdkdev.onmicrosoft.com",
+    "SignedOutCallbackPath": "/signout/B2C_1A_SIGNUP_SIGNIN",
+    "SignUpSignInPolicyId": "B2C_1A_SIGNUP_SIGNIN"
+    //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
+++ b/src/Saas.Permissions/Saas.Permissions.Api/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "AppSettings": {
+    "SelfSignedCertThumbprint": "thumbprinthere"
+
+  },
   "AzureAdB2C": {
     "Instance": "https://asdkdev.b2clogin.com",
     "ClientId": "e93c92d5-dfe8-4589-8fd8-7373816fa7e3",
@@ -13,7 +17,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "SelfSignedCertThumbprint": "thumbprinthere",
+  
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "PermissionsContext": "Server=(localdb)\\mssqllocaldb;Database=Saas.Permissions.Sql;Trusted_Connection=True;MultipleActiveResultSets=true"

--- a/src/Saas.Permissions/Saas.Permissions.Api/readme.md
+++ b/src/Saas.Permissions/Saas.Permissions.Api/readme.md
@@ -1,0 +1,15 @@
+Permissions API supports two auth schemes:
+- JWT/AAD Auth
+- Certificate Auth
+
+
+Permissions Controller only supports JWT/AAD Auth
+CustomClaims Controller only support certificate auth
+
+
+To auth with certificate auth, generate a self signed certificate (not reccomended for prod use). Place the thumbprint in the `SelfSignedCertThumbprint` app setting. 
+Certificate needs to be sent in a .cer format (b64 string) in the `X-ARR-ClientCert` Header. Auth will only succeed if the thumbprints match. Need to add docs on how to add futher validation if needed
+
+https://docs.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
+
+https://docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth


### PR DESCRIPTION
Added JWT/AAD Auth and Certificate based auth to permissions API. 

Permissions API will require the scope `access_as_user_via_admin_api` within the bearer token to call the permissions controller. 

To get custom claims, it will require a certificate to be present in the `X-ARR-ClientCert` (set by app service, but [configurable for most web servers](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth?view=aspnetcore-6.0#configure-your-server-to-require-certificates)). It will verify that the thumbprint matches the thumbprint set in the app config value. 

Samples used here:
https://docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth?view=aspnetcore-6.0#configure-your-server-to-require-certificates
https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-web-api-call-api-overview


https://docs.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
https://docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth?view=aspnetcore-6.0#configure-your-server-to-require-certificates