### PR TITLE
Set Admin Scopes Into Config

### DIFF
--- a/src/Saas.Application/Saas.Application.Web/Program.cs
+++ b/src/Saas.Application/Saas.Application.Web/Program.cs
@@ -68,6 +68,9 @@ for (var i = 0; i < adminServiceScopes.Length; i++)
     adminServiceScopes[i] = String.Format("{0}/{1}", adminServiceScopeBaseUrl, adminServiceScopes[i].Trim('/'));
 }
 
+// Set the newly-constructed form into memory for lookup when contacting Azure AD B2C later
+builder.Configuration[SR.AdminServiceScopesProperty] = string.Join(' ', adminServiceScopes);
+
 builder.Services.AddMicrosoftIdentityWebAppAuthentication(builder.Configuration, Constants.AzureAdB2C)
     .EnableTokenAcquisitionToCallDownstreamApi(adminServiceScopes)
     .AddSessionTokenCaches();


### PR DESCRIPTION
* Azure AD B2C will filter for the admin scopes during integration, so an assembled form must be set into memory