### PR TITLE
Upgrading to .NET 8 - adding Apple Silicon Fixes and dependency fixes

### DIFF
--- a/.github/workflows/admin-service-api-deploy.yml
+++ b/.github/workflows/admin-service-api-deploy.yml
@@ -9,9 +9,9 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'admin-api-asdk-test-83sx'       # set this to your application's name
+  AZURE_WEBAPP_NAME: 'admin-api-asdk-test-v23y'       # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Admin/Saas.Admin.Service
   PROJECT_PATH: ./src/Saas.Admin/Saas.Admin.Service/Saas.Admin.Service.csproj
   OUTPUT_PATH: ./publish/admin-api

--- a/.github/workflows/permissions-api-deploy.yml
+++ b/.github/workflows/permissions-api-deploy.yml
@@ -9,9 +9,9 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'api-permission-asdk-test-83sx' # set this to your application's name
+  AZURE_WEBAPP_NAME: 'api-permission-asdk-test-v23y' # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1
   PROJECT_PATH: ./src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1/Saas.Permissions.Service.csproj
   OUTPUT_PATH: ./publish/api-permission

--- a/.github/workflows/saas-app-deploy.yml
+++ b/.github/workflows/saas-app-deploy.yml
@@ -9,9 +9,9 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'saas-app-asdk-test-83sx'       # set this to your application's name
+  AZURE_WEBAPP_NAME: 'saas-app-asdk-test-v23y'       # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Application/Saas.Application.Web
   PROJECT_PATH: ./src/Saas.Application/Saas.Application.Web/Saas.Application.Web.csproj
   OUTPUT_PATH: ./publish/saas-app

--- a/.github/workflows/signup-administration-deploy.yml
+++ b/.github/workflows/signup-administration-deploy.yml
@@ -9,9 +9,9 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'signupadmin-app-asdk-test-83sx' # set this to your application's name
+  AZURE_WEBAPP_NAME: 'signupadmin-app-asdk-test-v23y' # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.SignupAdministration/Saas.SignupAdministration.Web
   PROJECT_PATH: ./src/Saas.SignupAdministration/Saas.SignupAdministration.Web/Saas.SignupAdministration.Web.csproj
   OUTPUT_PATH: ./publish/signupadmin

--- a/src/Saas.Admin/Saas.Admin.Client/Saas.Admin.Client.csproj
+++ b/src/Saas.Admin/Saas.Admin.Client/Saas.Admin.Client.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Multi Debug</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.15.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Saas.Admin/Saas.Admin.Service/Saas.Admin.Service.csproj
+++ b/src/Saas.Admin/Saas.Admin.Service/Saas.Admin.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-Saas.Admin.Service-5358E0C3-EA51-44EA-B381-CA2F9D9710D3</UserSecretsId>
@@ -11,11 +11,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
 		<PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="6.1.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/Saas.Admin/deployment/act/deploy.sh
+++ b/src/Saas.Admin/deployment/act/deploy.sh
@@ -17,6 +17,7 @@ container_deployment_dir="/asdk/src/Saas.Admin/deployment"
 
 # running the './act/script/patch-app-name.sh' script using our ASDK deployment script container - i.e., not the act container
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Admin/deployment/act/workflows/admin-service-api-deploy-debug.yml
+++ b/src/Saas.Admin/deployment/act/workflows/admin-service-api-deploy-debug.yml
@@ -10,9 +10,9 @@ permissions:
 
 env:
   APP_NAME: admin-api
-  AZURE_WEBAPP_NAME: admin-api-asdk-test-83sx          # set this to your application's name
+  AZURE_WEBAPP_NAME: admin-api-asdk-test-v23y          # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Admin/Saas.Admin.Service
   PROJECT_PATH: ${{ env.PROJECT_DIR }}/Saas.Admin.Service.csproj
   PUBLISH_PATH: ./publish

--- a/src/Saas.Admin/deployment/run.sh
+++ b/src/Saas.Admin/deployment/run.sh
@@ -11,6 +11,7 @@ container_deployment_dir="/asdk/src/Saas.Admin/deployment"
 # using volumes '--volume' to mount only the needed directories to the container.
 # using ':ro' to make scrip directories etc. read-only. Only config and log directories are writable.
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Application/Saas.Application.Web/Saas.Application.Web.csproj
+++ b/src/Saas.Application/Saas.Application.Web/Saas.Application.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>a45ad9f7-37e3-4dc7-bf2c-9f1f3e449cba</UserSecretsId>
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="6.1.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.15.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Saas.Application/deployment/act/deploy.sh
+++ b/src/Saas.Application/deployment/act/deploy.sh
@@ -17,6 +17,7 @@ container_deployment_dir="/asdk/src/Saas.Application/deployment"
 
 # running the './act/script/patch-app-name.sh' script using our ASDK deployment script container - i.e., not the act container
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Application/deployment/act/workflows/saas-app-deploy-debug.yml
+++ b/src/Saas.Application/deployment/act/workflows/saas-app-deploy-debug.yml
@@ -10,9 +10,9 @@ permissions:
 
 env:
   APP_NAME: saas-app
-  AZURE_WEBAPP_NAME: saas-app-asdk-test-83sx       # set this to your application's name
+  AZURE_WEBAPP_NAME: saas-app-asdk-test-v23y       # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Application/Saas.Application.Web
   PROJECT_PATH: ${{ env.PROJECT_DIR }}/Saas.Application.Web.csproj
   PUBLISH_PATH: ./publish

--- a/src/Saas.Application/deployment/run.sh
+++ b/src/Saas.Application/deployment/run.sh
@@ -11,6 +11,7 @@ container_deployment_dir="/asdk/src/Saas.Application/deployment"
 # using volumes '--volume' to mount only the needed directories to the container.
 # using ':ro' to make scrip directories etc. read-only. Only config and log directories are writable.
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/bicep/.gitignore
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/bicep/.gitignore
@@ -1,0 +1,1 @@
+deployStorage.json

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
@@ -25,11 +25,13 @@ docker run \
     --volume "${repo_base}/src/Saas.Lib/Deployment.Script.Modules":/asdk/src/Saas.Lib/Deployment.Script.Modules:ro \
     --volume "${repo_base}/src/Saas.Lib/Saas.Bicep.Module":/asdk/src/Saas.Lib/Saas.Bicep.Module:ro \
     --volume "${repo_base}/.git/":/asdk/.git:ro \
-    --volume "${HOME}/.azure/":/asdk/.azure:ro \
+    --volume "${HOME}/.azure/msal_token_cache.json":/root/.azure/msal_token_cache.json:ro \
+    --volume "${HOME}/.azure/azureProfile.json":/root/.azure/azureProfile.json:ro \
     --volume "${HOME}/asdk/.cache/":/asdk/.cache \
     --env "ASDK_DEPLOYMENT_SCRIPT_PROJECT_BASE=/asdk/src/Saas.Identity/Saas.IdentityProvider/deployment" \
     --env "GIT_REPO_ORIGIN=${git_repo_origin}" \
     --env "GIT_ORG_PROJECT_NAME=${git_org_project_name}" \
     --env "GITHUB_AUTH_TOKEN=${gh_auth_token}" \
-    asdk-script-deployment:latest \
-    bash /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh
+    --platform linux/amd64 \
+    asdk-script-deployment:latest
+# bash /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
@@ -33,5 +33,5 @@ docker run \
     --env "GIT_ORG_PROJECT_NAME=${git_org_project_name}" \
     --env "GITHUB_AUTH_TOKEN=${gh_auth_token}" \
     --platform linux/amd64 \
-    asdk-script-deployment:latest
-# bash /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh
+    asdk-script-deployment:latest \
+bash # /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
@@ -15,6 +15,7 @@ fi
 # using volumes '--volume' to mount only the needed directories to the container.
 # using ':ro' to make scrip directories etc. read-only. Only config and log directories are writable.
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \
@@ -25,13 +26,11 @@ docker run \
     --volume "${repo_base}/src/Saas.Lib/Deployment.Script.Modules":/asdk/src/Saas.Lib/Deployment.Script.Modules:ro \
     --volume "${repo_base}/src/Saas.Lib/Saas.Bicep.Module":/asdk/src/Saas.Lib/Saas.Bicep.Module:ro \
     --volume "${repo_base}/.git/":/asdk/.git:ro \
-    --volume "${HOME}/.azure/msal_token_cache.json":/root/.azure/msal_token_cache.json:ro \
-    --volume "${HOME}/.azure/azureProfile.json":/root/.azure/azureProfile.json:ro \
+    --volume "${HOME}/.azure/":/asdk/.azure:ro \
     --volume "${HOME}/asdk/.cache/":/asdk/.cache \
     --env "ASDK_DEPLOYMENT_SCRIPT_PROJECT_BASE=/asdk/src/Saas.Identity/Saas.IdentityProvider/deployment" \
     --env "GIT_REPO_ORIGIN=${git_repo_origin}" \
     --env "GIT_ORG_PROJECT_NAME=${git_org_project_name}" \
     --env "GITHUB_AUTH_TOKEN=${gh_auth_token}" \
-    --platform linux/amd64 \
     asdk-script-deployment:latest \
-bash # /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh
+    bash /asdk/src/Saas.Identity/Saas.IdentityProvider/deployment/start.sh

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/script/config-b2c.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/script/config-b2c.sh
@@ -46,7 +46,7 @@ for app in "${app_reg_array[@]}"; do
 
     if [[ "${has_secret}" == true || "${has_secret}" == "true" ]]; then
         app_name=$(jq --raw-output '.name' <<<"${app}")
-        secret_path=$(jq --raw-output '.secretPath' <<<"${app}")
+        secret_path=$(jq --raw-output '.secretPath' <<< "${app}")
 
         if [[ -s "${secret_path}" ]]; then
 

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/script/init.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/script/init.sh
@@ -20,7 +20,7 @@ function check-prerequisites() {
             --header "Checking prerequisites"
 
     what_os="$(get-os)" ||
-        echo "Unsupported OS: ${what_os}. This script support linux and macos." |
+        echo "Unsupported OS: ${what_os}. This script support linux (WSL 2.0 on Windows) and MacOS." |
         log-output \
             --level error \
             --header "Critical Error" ||

--- a/src/Saas.Identity/Saas.IdentityProvider/readme.md
+++ b/src/Saas.Identity/Saas.IdentityProvider/readme.md
@@ -20,7 +20,7 @@ For more details please read the [FAQ](./faq.md):
 
 Running the deployment script requires utilizing a container and Docker. 
 
-### Prerequisites 
+### Prerequisites
 
 The following platforms are supported:
 
@@ -84,6 +84,8 @@ To run the script you must first setup of the deployment environment and build t
 ```bash
 ./setup.sh
 ```
+
+> *Tip#1: On MacOS, you may need to run `chmod +x setup.sh` first, to make the script executable.*
 
 ![Screenshot of a Linux console window after initial setup.sh execution](.assets/readme/image-20230221115203497-1683889385776-2.png)
 

--- a/src/Saas.Identity/Saas.Permissions/Saas.Permissions.Client/Saas.Permissions.Client.csproj
+++ b/src/Saas.Identity/Saas.Permissions/Saas.Permissions.Client/Saas.Permissions.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Multi Debug</Configurations>

--- a/src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1/Saas.Permissions.Service.csproj
+++ b/src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1/Saas.Permissions.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>2f007af4-43b5-4316-903b-03340f0999e4</UserSecretsId>
@@ -16,11 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="6.1.1" />
-	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.13" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Saas.Identity/Saas.Permissions/deployment/act/deploy.sh
+++ b/src/Saas.Identity/Saas.Permissions/deployment/act/deploy.sh
@@ -17,6 +17,7 @@ container_deployment_dir="/asdk/src/Saas.Identity/Saas.Permissions/deployment"
 
 # running the './act/script/patch-app-name.sh' script using our ASDK deployment script container - i.e., not the act container
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Identity/Saas.Permissions/deployment/act/workflows/permissions-api-deploy-debug.yml
+++ b/src/Saas.Identity/Saas.Permissions/deployment/act/workflows/permissions-api-deploy-debug.yml
@@ -10,9 +10,9 @@ permissions:
 
 env:
   APP_NAME: permissions-api
-  AZURE_WEBAPP_NAME: api-permission-asdk-test-83sx        # set this to your application's name
+  AZURE_WEBAPP_NAME: api-permission-asdk-test-v23y        # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: "." # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1
   PROJECT_PATH: ${{ env.PROJECT_DIR }}/Saas.Permissions.Service.csproj
   PUBLISH_PATH: ./publish

--- a/src/Saas.Identity/Saas.Permissions/deployment/run.sh
+++ b/src/Saas.Identity/Saas.Permissions/deployment/run.sh
@@ -11,6 +11,7 @@ container_deployment_dir="/asdk/src/Saas.Identity/Saas.Permissions/deployment"
 # using volumes '--volume' to mount only the needed directories to the container.
 # using ':ro' to make scrip directories etc. read-only. Only config and log directories are writable.
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.Lib/Act.Container/build.sh
+++ b/src/Saas.Lib/Act.Container/build.sh
@@ -26,3 +26,4 @@ else
     docker build --no-cache --file "${ACT_CONTAINER_DIR}/Dockerfile" --tag "${tag_name}" .
 fi
 
+gh extension install https://github.com/nektos/gh-act

--- a/src/Saas.Lib/Deployment.Container/Dockerfile.AppleSilicon
+++ b/src/Saas.Lib/Deployment.Container/Dockerfile.AppleSilicon
@@ -28,5 +28,9 @@ RUN pip3 install PyYaml
     
 WORKDIR /asdk
 
+# Workaround for the dotnet 7 execution with rosetta2 emulation
+# https://github.com/Azure/bicep/issues/10245#issuecomment-1816816017
+ENV DOTNET_EnableWriteXorExecute=0
+
 # trust repository in container
 RUN git config --global --add safe.directory /asdk

--- a/src/Saas.Lib/Deployment.Container/Dockerfile.AppleSilicon
+++ b/src/Saas.Lib/Deployment.Container/Dockerfile.AppleSilicon
@@ -1,0 +1,32 @@
+FROM --platform=linux/amd64 ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    dnsutils \
+    python3-pip \
+    jq \
+    sudo \
+    libicu-dev \
+    uuid-runtime \
+    zip \
+    dos2unix \
+    python3-ruamel.yaml \
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+# Install latest GitHub cli (gh)
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update \
+    && sudo apt install gh -y
+
+RUN pip3 install PyYaml
+
+# Install Azure Cli extension 'Storage-preview'
+# RUN az extension add --name storage-preview
+    
+WORKDIR /asdk
+
+# trust repository in container
+RUN git config --global --add safe.directory /asdk

--- a/src/Saas.Lib/Deployment.Container/build.sh
+++ b/src/Saas.Lib/Deployment.Container/build.sh
@@ -1,33 +1,58 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
+source "./constants.sh"
+source "$SHARED_MODULE_DIR/util-module.sh"
+
 force_update=false
 
-while getopts f flag
-do
+while getopts f flag; do
     case "${flag}" in
-        f) force_update=true;;
-        *) force_update=false;;
+    f) force_update=true ;;
+    *) force_update=false ;;
     esac
 done
 
-repo_base="$( git rev-parse --show-toplevel )"
+repo_base="$(git rev-parse --show-toplevel)"
 docker_file_folder="${repo_base}/src/Saas.Lib/Deployment.Container"
 
-architecture="$( uname -a )"
+architecture="$(uname -a)"
 
-if [[ "${force_update}" == false  ]]; then
+what_os="$(get-os)" ||
+    echo "Unsupported OS: ${what_os}. This script support linux (ubxl.WSL 2.0 on Windows) and MacOS." |
+    log-output \
+        --level error \
+        --header "Critical Error" ||
+    exit 1
+
+if [[ "${force_update}" == false ]]; then
     if [[ "${architecture}" == *"ARM64"* ]]; then
-        echo "Building for ARM64 (including Apple Sillicon)..."
-        docker build --file "${docker_file_folder}/Dockerfile.ARM" --tag asdk-script-deployment:latest .
+        if [[ "${what_os}" == "linux" ]]; then
+            echo "Building for Linux on Arm)..."
+            docker build --file "${docker_file_folder}/Dockerfile.ARM" --tag asdk-script-deployment:latest .
+        elif [[ "${what_os}" == "macos" ]]; then
+            echo "Building for MacOS on Apple Silicon"
+            docker build --file "${docker_file_folder}/Dockerfile.AppleSilicon" --tag asdk-script-deployment:latest .
+        else
+            exit 1
+        fi
     else
+        echo "Building for Linux (incl. WSL 2.0 on Windows) on x86_64)..."
         docker build --file "${docker_file_folder}/Dockerfile" --tag asdk-script-deployment:latest .
     fi
 else
     if [[ "${architecture}" == *"ARM64"* ]]; then
-        echo "Building for ARM64 (including Apple Sillicon)..."
-        docker build --no-cache --file "${docker_file_folder}/Dockerfile.ARM" --tag asdk-script-deployment:latest .
+        if [[ "${what_os}" == "linux" ]]; then
+            echo "Force building for Linux on Arm)..."
+            docker build --no-cache --file "${docker_file_folder}/Dockerfile.ARM" --tag asdk-script-deployment:latest .
+        elif [[ "${what_os}" == "macos" ]]; then
+            echo "Force building for MacOS on Apple Silicon"
+            docker build --no-cache --file "${docker_file_folder}/Dockerfile.AppleSilicon" --tag asdk-script-deployment:latest .
+        else
+            exit 1
+        fi
     else
+        echo "Force building for Linux (incl. WSL 2.0 on Windows) on x86_64)..."
         docker build --no-cache --file "${docker_file_folder}/Dockerfile" --tag asdk-script-deployment:latest .
     fi
 fi
-

--- a/src/Saas.Lib/Deployment.Script.Modules/deploy-app-service.sh
+++ b/src/Saas.Lib/Deployment.Script.Modules/deploy-app-service.sh
@@ -15,15 +15,17 @@ prepare-parameters-file "${BICEP_PARAMETERS_TEMPLATE_FILE}" "${BICEP_APP_SERVICE
 
 resource_group="$(get-value ".deployment.resourceGroup.name")"
 identity_foundation_deployment_name="$(get-value ".deployment.identityFoundation.name")"
+subscriptionId="$(get-value ".initConfig.subscriptionId")"
 
-echo "Downloading Identity Foundation outputs from Resource Group '${resource_group}' deployment named '${identity_foundation_deployment_name}'..." |
+echo "Deploying App Service: Downloading Identity Foundation outputs from Resource Group '${resource_group}' deployment named '${identity_foundation_deployment_name}'..." |
     log-output \
         --level info
 
 get-identity-foundation-deployment-outputs \
     "${resource_group}" \
     "${identity_foundation_deployment_name}" \
-    "${BICEP_IDENTITY_FOUNDATION_OUTPUT_FILE}"
+    "${BICEP_IDENTITY_FOUNDATION_OUTPUT_FILE}" \
+    "${subscriptionId}"
 
 echo "Mapping '${APP_NAME}' parameters..." |
     log-output \

--- a/src/Saas.Lib/Deployment.Script.Modules/deploy-config-entries.sh
+++ b/src/Saas.Lib/Deployment.Script.Modules/deploy-config-entries.sh
@@ -15,15 +15,17 @@ prepare-parameters-file "${BICEP_PARAMETERS_TEMPLATE_FILE}" "${BICEP_CONFIG_ENTR
 
 resource_group="$(get-value ".deployment.resourceGroup.name")"
 identity_foundation_deployment_name="$(get-value ".deployment.identityFoundation.name")"
+subscriptionId="$(get-value ".initConfig.subscriptionId")"
 
-echo "Downloading Identity Foundation outputs from Resource Group '${resource_group}' deployment named '${identity_foundation_deployment_name}'..." |
+echo "Deploying Config Entries: Downloading Identity Foundation outputs from Resource Group '${resource_group}' deployment named '${identity_foundation_deployment_name}'..." |
     log-output \
         --level info
 
 get-identity-foundation-deployment-outputs \
     "${resource_group}" \
     "${identity_foundation_deployment_name}" \
-    "${BICEP_IDENTITY_FOUNDATION_OUTPUT_FILE}"
+    "${BICEP_IDENTITY_FOUNDATION_OUTPUT_FILE}" \
+    "${subscriptionId}"
 
 echo "Provisioning the ${APP_NAME} Configuration Entries." |
     log-output \

--- a/src/Saas.Lib/Deployment.Script.Modules/deploy-service-module.sh
+++ b/src/Saas.Lib/Deployment.Script.Modules/deploy-service-module.sh
@@ -17,7 +17,7 @@ function deploy-service() {
         --name "${deployment_name}" \
         --template-file "${template_file}" \
         --parameters "${parameters_file}" \
-        || echo "Failed to deploy to ${APP_NAME}. This sometimes happens for no apperent reason. Please try again." \
+        || echo "Failed to deploy to ${APP_NAME}. This sometimes happens, please try again." \
             | log-output \
                 --level error \
                 --header "Critical Error" \
@@ -28,6 +28,14 @@ function get-identity-foundation-deployment-outputs() {
     local resource_group="$1"
     local deployment_name="$2"
     local output_file="$3"
+    local subscriptionId="$4"
+
+    az account set --subscription "${subscriptionId}" \
+        || echo "Failed to set subscription to ${subscriptionId}" \
+            | log-output \
+                --level error \
+                --header "Critical Error" \
+                || exit 1
 
     deployment_output_parameters="$( az deployment group show \
         --name "${deployment_name}" \

--- a/src/Saas.Lib/Saas.Identity/Saas.Identity.csproj
+++ b/src/Saas.Lib/Saas.Identity/Saas.Identity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Multi Debug</Configurations>
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
-	<PackageReference Include="Microsoft.Identity.Web" Version="2.15.3" />
-    <PackageReference Include="Microsoft.Graph" Version="5.32.0" />
+	<PackageReference Include="Microsoft.Identity.Web" Version="2.16.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.37.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Saas.Lib/Saas.Shared/Saas.Shared.csproj
+++ b/src/Saas.Lib/Saas.Shared/Saas.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Multi Debug</Configurations>

--- a/src/Saas.SignupAdministration/Saas.SignupAdministration.Web/Saas.SignupAdministration.Web.csproj
+++ b/src/Saas.SignupAdministration/Saas.SignupAdministration.Web/Saas.SignupAdministration.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
     <UserSecretsId>7b599cf5-3102-4740-ab34-69dd240f9ea3</UserSecretsId>
     <ApplicationInsightsResourceId>/subscriptions/357c83c2-bed7-4fe7-af6a-95835c6e2d91/resourceGroups/rg-saas-dev-001/providers/microsoft.insights/components/app-provider-dev-001</ApplicationInsightsResourceId>
@@ -17,12 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageReference Include="Dawn.Guard" Version="1.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="6.1.1" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.15.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.11" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Saas.SignupAdministration/deployment/act/deploy.sh
+++ b/src/Saas.SignupAdministration/deployment/act/deploy.sh
@@ -17,6 +17,7 @@ container_deployment_dir="/asdk/src/Saas.SignupAdministration/deployment"
 
 # running the './act/script/patch-app-name.sh' script using our ASDK deployment script container - i.e., not the act container
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \

--- a/src/Saas.SignupAdministration/deployment/act/workflows/signup-administration-deploy-debug.yml
+++ b/src/Saas.SignupAdministration/deployment/act/workflows/signup-administration-deploy-debug.yml
@@ -10,9 +10,9 @@ permissions:
 
 env:
   APP_NAME: signupadmin-app
-  AZURE_WEBAPP_NAME: signupadmin-app-asdk-test-83sx       # set this to your application's name
+  AZURE_WEBAPP_NAME: signupadmin-app-asdk-test-v23y       # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: 7.x.x
+  DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.SignupAdministration/Saas.SignupAdministration.Web
   PROJECT_PATH: ${{ env.PROJECT_DIR }}/Saas.SignupAdministration.Web.csproj
   PUBLISH_PATH: ./publish

--- a/src/Saas.SignupAdministration/deployment/run.sh
+++ b/src/Saas.SignupAdministration/deployment/run.sh
@@ -11,6 +11,7 @@ container_deployment_dir="/asdk/src/Saas.SignupAdministration/deployment"
 # using volumes '--volume' to mount only the needed directories to the container.
 # using ':ro' to make scrip directories etc. read-only. Only config and log directories are writable.
 docker run \
+    --platform linux/amd64 \
     --interactive \
     --tty \
     --rm \


### PR DESCRIPTION
.NET projects now upgraded to .NET 8.

The installation script was unable to complete successfully on Apple Silicon, due to as outlined in #252. 

#247 have also been addressed which was due to changes related to AZ CLI becoming more strict on setting the correct subscription. 