### PR TITLE
Microsoft Entra Rebrand

### DIFF
--- a/docs/azure-saas-docs/content/en/components/Identity/permissions-service.md
+++ b/docs/azure-saas-docs/content/en/components/Identity/permissions-service.md
@@ -43,7 +43,7 @@ The Permissions Service is secured using API Key Authentication. The API Key is 
 
 ### Microsoft Graph API
 
-The [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview) is an API that provides a unified experience for accessing data on users within an Azure AD or Azure AD B2C tenant. Since we are using Azure AD B2C as our default Identity Provider, we must also use the Graph API when it becomes necessary to fetch data on our users. If you'd like to replace the identity provider with something else, you must also replace the Graph API calls within the permissions service to gather user data. These areas are clearly labeled with comments inline with the code.
+The [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview) is an API that provides a unified experience for accessing data on users within a Microsoft Entra or Azure AD B2C tenant. Since we are using Azure AD B2C as our default Identity Provider, we must also use the Graph API when it becomes necessary to fetch data on our users. If you'd like to replace the identity provider with something else, you must also replace the Graph API calls within the permissions service to gather user data. These areas are clearly labeled with comments inline with the code.
 
 ### Swagger
 

--- a/docs/azure-saas-docs/content/en/quick-start.md
+++ b/docs/azure-saas-docs/content/en/quick-start.md
@@ -44,7 +44,7 @@ The Sign-up Administration Web Application provides a UI for adding new SaaS ten
 
 To provision the SaaS Sign-up Administration Web Application please follow the [readme](https://github.com/Azure/azure-saas/tree/main/src/Saas.SignupAdministration).
 
-> (*) Note that the term *tenant* is overloaded. A SaaS Tenant is not that same as an Azure AD tenant. The SaaS tenant references each instance of your multi-tenanted application.
+> (*) Note that the term *tenant* is overloaded. A SaaS Tenant is not that same as an Azure AD B2C or Microsoft Entra tenant. The SaaS tenant references each instance of your multi-tenanted application.
 
 ## Provisoning the Saas Application
 

--- a/docs/azure-saas-docs/content/en/resources/contoso-badgemeup.md
+++ b/docs/azure-saas-docs/content/en/resources/contoso-badgemeup.md
@@ -23,7 +23,7 @@ Lucerne Publishing has recently purchased Contoso BadgeMeUp. They're currently u
 ### Onboarding
 
 1. Phil in Lucerne Publishing accounting browsed the plans available at Signup.BadgeMeUp.Contoso.com and selected the plan he thought would best fit the company's needs.
-2. Sandy navigates to BadgeMeUp.Contoso.com/lucernepublishing and signs in using her Azure AD credentials.
+2. Sandy navigates to BadgeMeUp.Contoso.com/lucernepublishing and signs in using her Microsoft Entra credentials.
 3. After Sandy creates an account, Phil can then go to Signup.BadgeMeUp.Contoso.com/admin to see his previously created tenant and grant Sandy elevation permissions if he wishes. 
 
 ```mermaid

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,7 +43,7 @@
 ### Identity
 - ASP.NET Core Identity
 - Azure AD B2C
-- Azure AD
+- Microsoft Entra 
 
 ### Storage
 - Web Deployment Packages for all solutions components

--- a/src/Saas.Admin/deployment/bicep/deployConfigEntries.bicep
+++ b/src/Saas.Admin/deployment/bicep/deployConfigEntries.bicep
@@ -10,8 +10,8 @@ param azureB2CDomain string
 @description('Azure B2C Tenant Id.')
 param azureB2cTenantId string
 
-@description('Azure AD Instance')
-param azureAdInstance string
+@description('Azure AD B2C Instance')
+param azureAdB2CInstanceURL string
 
 @description('The Azure B2C Signed Out Call Back Path.')
 param signedOutCallBackPath string
@@ -99,7 +99,7 @@ var appConfigStore = {
     }
     {
       key: '${adminApiKeyName}:${azureB2CKeyName}:Instance'
-      value: azureAdInstance
+      value: azureAdB2CInstanceURL
       isSecret: false
       contentType: 'text/plain'
     }

--- a/src/Saas.Application/deployment/bicep/deployConfigEntries.bicep
+++ b/src/Saas.Application/deployment/bicep/deployConfigEntries.bicep
@@ -13,8 +13,8 @@ param azureB2CDomain string
 @description('Azure B2C Tenant Id.')
 param azureB2cTenantId string
 
-@description('Azure AD Instance')
-param azureAdInstance string
+@description('Azure AD B2C Instance')
+param azureAdB2CInstanceURL string
 
 @description('The Azure B2C Signed Out Call Back Path.')
 param signedOutCallBackPath string
@@ -81,7 +81,7 @@ var appConfigStore = {
     }
     {
       key: '${saasAppKeyName}:${azureB2CKeyName}:Instance'
-      value: azureAdInstance
+      value: azureAdB2CInstanceURL 
       isSecret: false
       contentType: 'text/plain'
     }

--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/script/clean-up-module.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/script/clean-up-module.sh
@@ -20,7 +20,7 @@ function clean-up-after-service-principal() {
     service_principal_credentials_file_path="$( get-user-value "${service_principal_username}" "credentialsPath" )"
     sudo rm -f "${service_principal_credentials_file_path}"
 
-    # deleting service principal credentials in Azure AD too
+    # deleting service principal credentials in Azure AD B2C too
     app_id="$( get-value ".deployment.azureb2c.servicePrincipal.appId" )"
     b2c_config_usr_name="$( get-value ".deployment.azureb2c.username" )"
     echo "Deleting service principal credentials using user '${b2c_config_usr_name}'" \
@@ -36,7 +36,7 @@ function clean-up-after-service-principal() {
     # resetting user context to the user that was used to login to the tenant
     reset-user-context
 
-    echo "Service principal credentials have been removed locally and in Azure AD." \
+    echo "Service principal credentials have been removed locally and in Azure AD B2C" \
         | log-output \
             --level success
 }

--- a/src/Saas.Identity/Saas.IdentityProvider/policies/TrustFrameworkBase.xml
+++ b/src/Saas.Identity/Saas.IdentityProvider/policies/TrustFrameworkBase.xml
@@ -20,7 +20,7 @@
               and/or sent in the token in Section III. -->
 
       <!-- NOTE: The claims schema contains restrictions on certain claims such as passwords and usernames. 
-           The trust framework policy treats Azure AD as any other claims provider and all its restrictions 
+           The trust framework policy treats Microsoft Entra as any other claims provider and all its restrictions 
            are modelled in the policy. A policy could be modified to add more restrictions, or use another 
            claims provider for credential storage which will have its own restrictions. -->
 
@@ -44,7 +44,7 @@
           <Protocol Name="OpenIdConnect" PartnerClaimType="tid" />
           <Protocol Name="SAML2" PartnerClaimType="http://schemas.microsoft.com/identity/claims/tenantid" />
         </DefaultPartnerClaimTypes>
-        <UserHelpText>Tenant identifier (ID) of the user object in Azure AD.</UserHelpText>
+        <UserHelpText>Tenant identifier (ID) of the user object in Microsoft Entra.</UserHelpText>
       </ClaimType>
 
       <ClaimType Id="objectId">
@@ -55,7 +55,7 @@
           <Protocol Name="OpenIdConnect" PartnerClaimType="oid" />
           <Protocol Name="SAML2" PartnerClaimType="http://schemas.microsoft.com/identity/claims/objectidentifier" />
         </DefaultPartnerClaimTypes>
-        <UserHelpText>Object identifier (ID) of the user object in Azure AD.</UserHelpText>
+        <UserHelpText>Object identifier (ID) of the user object in Microsoft Entra.</UserHelpText>
       </ClaimType>
 
       <!-- Claims needed for local accounts. -->
@@ -125,7 +125,7 @@
       <ClaimType Id="passwordPolicies">
         <DisplayName>Password Policies</DisplayName>
         <DataType>string</DataType>
-        <UserHelpText>Password policies used by Azure AD to determine password strength, expiry etc.</UserHelpText>
+        <UserHelpText>Password policies used by Microsoft Entra to determine password strength, expiry etc.</UserHelpText>
       </ClaimType>
 
       <ClaimType Id="client_id">

--- a/src/Saas.Identity/Saas.IdentityProvider/readme.md
+++ b/src/Saas.Identity/Saas.IdentityProvider/readme.md
@@ -187,7 +187,7 @@ Other values in `initConfig`:
 | ---------------------- | --------- | ------------------------------------------------------------ |
 | `solutionPrefix`       | asdk      | The suggestion is to leave it as-is.                         |
 | `solutionName`         | test      | The suggestion is to leave it as default or limit it to four letters. |
-| `azureb2c/location`    | N/A       | Note that this is not the same as the location above, but is rather the names of the Azure AD regions available. Unfortunately, there's currently no command available for getting the list. |
+| `azureb2c/location`    | N/A       | Note that this is not the same as the location above, but is rather the names of the Azure AD B2C regions available. Unfortunately, there's currently no command available for getting the list. |
 | `azureb2c/countryCode` | N/A       | An available ISO country code                                |
 | `azureb2c/skuName`     | PremiumP1 | Available options are `Standard`, `Premium1` and `Premium2`  |
 | `azureb2c/tier`        | A0        | No known alternatives at the moment, please leave it as-is.  |

--- a/src/Saas.Identity/Saas.Permissions/deployment/bicep/deployConfigEntries.bicep
+++ b/src/Saas.Identity/Saas.Permissions/deployment/bicep/deployConfigEntries.bicep
@@ -13,8 +13,8 @@ param azureB2CDomain string
 @description('Azure B2C Tenant Id.')
 param azureB2cTenantId string
 
-@description('Azure AD Instance')
-param azureAdInstance string
+@description('Azure AD B2C Instance')
+param azureAdB2CInstanceURL string
 
 @description('The Azure B2C Signed Out Call Back Path.')
 param signedOutCallBackPath string
@@ -92,7 +92,7 @@ var appConfigStore = {
     }
     {
       key: '${permissionsApiKeyName}:${azureB2CKeyName}:Instance'
-      value: azureAdInstance
+      value: azureAdB2CInstanceURL 
       isSecret: false
       contentType: 'text/plain'
     }

--- a/src/Saas.Lib/Deployment.Script.Modules/clean-credentials.sh
+++ b/src/Saas.Lib/Deployment.Script.Modules/clean-credentials.sh
@@ -18,5 +18,5 @@ initialize-az-cli "$HOME/.azure"
 # remove locally cached secret
 sudo rm "${ACT_SECRETS_FILE}" 2> /dev/null
 
-# delete secret based credential in Azure AD app registration.
+# delete secret based credential in Azure AD B2C app registration.
 delete-secret-based-credentials

--- a/src/Saas.SignupAdministration/Saas.SignupAdministration.Web/SR.cs
+++ b/src/Saas.SignupAdministration/Saas.SignupAdministration.Web/SR.cs
@@ -101,8 +101,8 @@ public static class SR
     public const string CatalogCustomerSelectQuery = "SELECT * FROM dbo.Customer Where TenantId = " + CatalogTenantIdParameter;
     public const string CatalogTenantSelectQuery = "SELECT Id  FROM Tenant WHERE ApiKey = " + CatalogApiKeyParameter;
 
-    // Azure AD Properties
-    public const string AzureAdAuthorityFormat = "https://login.microsoftonline.com/{0}/v2.0";
+    // Azure AD B2C Properties
+    public const string AzureAdB2CAuthorityFormat = "https://login.microsoftonline.com/{0}/v2.0";
 
     // Startup Properties
     public const string IdentityDbConnectionProperty = "IdentityDbConnection";

--- a/src/Saas.SignupAdministration/deployment/bicep/deployConfigEntries.bicep
+++ b/src/Saas.SignupAdministration/deployment/bicep/deployConfigEntries.bicep
@@ -13,8 +13,8 @@ param azureB2CDomain string
 @description('Azure B2C Tenant Id.')
 param azureB2cTenantId string
 
-@description('Azure AD Instance')
-param azureAdInstance string
+@description('Azure AD B2C Instance')
+param azureAdB2CInstanceURL string
 
 @description('The Azure B2C Signed Out Call Back Path.')
 param signedOutCallBackPath string
@@ -91,7 +91,7 @@ var appConfigStore = {
     }
     {
       key: '${signupAdminKeyName}:${azureB2CKeyName}:Instance'
-      value: azureAdInstance
+      value: azureAdB2CInstanceURL
       isSecret: false
       contentType: 'text/plain'
     }


### PR DESCRIPTION
Changed several references from Azure AD to Azure AD B2C or Microsoft Entra where appropriate. 

@1iveowl double check behind me, but it looked like the property in `src/Saas.SignupAdministration/Saas.SignupAdministration.Web/SR.cs` was not used anywhere else, so we shouldn't need to change it elsewhere. 