### PR TITLE
Update Azure AD B2C instance URL parameter name in deployment scripts

### DIFF
--- a/src/Saas.Admin/deployment/script/map-to-config-entries-parameters.py
+++ b/src/Saas.Admin/deployment/script/map-to-config-entries-parameters.py
@@ -101,7 +101,7 @@ def patch_paramenters_file(
     
     parameters['parameters'].update(get_deploy_b2c_value(config, 'domainName', 'azureB2CDomain'))
     parameters['parameters'].update(get_deploy_b2c_value(config, 'tenantId', 'azureB2cTenantId'))
-    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdInstance'))
+    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdB2CInstanceURL'))
 
     parameters['parameters'].update(get_b2c_value(config, 'signedOutCallBackPath', 'signedOutCallBackPath'))
     parameters['parameters'].update(get_b2c_value(config, 'signUpSignInPolicyId', 'signUpSignInPolicyId'))

--- a/src/Saas.Application/deployment/script/map-to-config-entries-parameters.py
+++ b/src/Saas.Application/deployment/script/map-to-config-entries-parameters.py
@@ -75,7 +75,7 @@ def patch_paramenters_file(
     
     parameters['parameters'].update(get_deploy_b2c_value(config, 'domainName', 'azureB2CDomain'))
     parameters['parameters'].update(get_deploy_b2c_value(config, 'tenantId', 'azureB2cTenantId'))
-    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdInstance'))
+    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdB2CInstanceURL'))
     
     parameters['parameters'].update(get_b2c_value(config, 'signedOutCallBackPath', 'signedOutCallBackPath'))
     parameters['parameters'].update(get_b2c_value(config, 'signUpSignInPolicyId', 'signUpSignInPolicyId'))

--- a/src/Saas.Identity/Saas.Permissions/deployment/script/map-to-config-entries-parameters.py
+++ b/src/Saas.Identity/Saas.Permissions/deployment/script/map-to-config-entries-parameters.py
@@ -105,7 +105,7 @@ def patch_paramenters_file(
     
     parameters['parameters'].update(get_deploy_b2c_value(config, 'domainName', 'azureB2CDomain'))
     parameters['parameters'].update(get_deploy_b2c_value(config, 'tenantId', 'azureB2cTenantId'))
-    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdInstance'))
+    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdB2CInstanceURL'))
     
     parameters['parameters'].update(get_b2c_value(config, 'signedOutCallBackPath', 'signedOutCallBackPath'))
     parameters['parameters'].update(get_b2c_value(config, 'signUpSignInPolicyId', 'signUpSignInPolicyId'))

--- a/src/Saas.SignupAdministration/deployment/script/map-to-config-entries-parameters.py
+++ b/src/Saas.SignupAdministration/deployment/script/map-to-config-entries-parameters.py
@@ -87,7 +87,7 @@ def patch_paramenters_file(
     
     parameters['parameters'].update(get_deploy_b2c_value(config, 'domainName', 'azureB2CDomain'))
     parameters['parameters'].update(get_deploy_b2c_value(config, 'tenantId', 'azureB2cTenantId'))
-    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdInstance'))
+    parameters['parameters'].update(get_deploy_b2c_value(config, 'instance', 'azureAdB2CInstanceURL'))
     
     parameters['parameters'].update(get_b2c_value(config, 'signedOutCallBackPath', 'signedOutCallBackPath'))
     parameters['parameters'].update(get_b2c_value(config, 'signUpSignInPolicyId', 'signUpSignInPolicyId'))


### PR DESCRIPTION
This corrects the mismatch between the parameter names for AD B2C instance URL in the Bicep files and the map-to-config-entries-parameters.py scripts.

This resolves the issue reported here: https://github.com/Azure/azure-saas/issues/257#issuecomment-1951664310