### PR TITLE
Update broken parameter on service principal login

### DIFF
--- a/.github/workflows/admin-service-api-deploy.yml
+++ b/.github/workflows/admin-service-api-deploy.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'admin-api-asdk-test-v23y'       # set this to your application's name
+  AZURE_WEBAPP_NAME: 'admin-api-asdk-tst4-08dt'       # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
   DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Admin/Saas.Admin.Service

--- a/.github/workflows/permissions-api-deploy.yml
+++ b/.github/workflows/permissions-api-deploy.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  AZURE_WEBAPP_NAME: 'api-permission-asdk-test-v23y' # set this to your application's name
+  AZURE_WEBAPP_NAME: 'api-permission-asdk-tst4-08dt' # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: . # set this to the path to your web app project, defaults to the repository root
   DOTNET_VERSION: 8.x.x
   PROJECT_DIR: ./src/Saas.Identity/Saas.Permissions/Saas.Permissions.Service_v1.1

--- a/src/Saas.Identity/Saas.IdentityProvider/readme.md
+++ b/src/Saas.Identity/Saas.IdentityProvider/readme.md
@@ -1,6 +1,6 @@
 # Deploying the Identity Foundation Services
 
-This deployment script provisions and configures the Azure services defining the SaaS Identify Foundation, which is back-bone of the Azure SaaS Dev Kit. 
+This deployment script provisions and configures the Azure services defining the SaaS Identify Foundation, the back-bone of the Azure SaaS Dev Kit. 
 
 ## Before You begin
 

--- a/src/Saas.Lib/Deployment.Script.Modules/service-principal-module.sh
+++ b/src/Saas.Lib/Deployment.Script.Modules/service-principal-module.sh
@@ -293,7 +293,7 @@ function service-principal-login() {
     az login \
         --service-principal \
         --username "${app_id}" \
-        --password "${credentials_path}" \
+        --certificate "${credentials_path}" \
         --tenant "${b2c_tenant_id}" \
         --allow-no-subscriptions > /dev/null \
     || echo "Failed to login with service principal." \


### PR DESCRIPTION
Az CLI 2.69.0 (current) erroring with --password pointing to certificate.
Also minor grammar tweak.