### PR TITLE
Add support for repo cloned using SSH

### DIFF
--- a/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
+++ b/src/Saas.Identity/Saas.IdentityProvider/deployment/run.sh
@@ -2,7 +2,7 @@
 
 repo_base="$(git rev-parse --show-toplevel)"
 git_repo_origin="$(git config --get remote.origin.url)"
-git_org_project_name="$(git config --get remote.origin.url | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/')"
+git_org_project_name="$(git config --get remote.origin.url | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/' | sed 's/.*:\(.*\)\.git/\1/')"
 gh_auth_token="$(gh auth token)"
 
 if [[ -z "${gh_auth_token}" ]]; then


### PR DESCRIPTION
Fixes #265.

## Before the change

Note that if you clone the repo using SSH, the `sed` substitution is not working.
But it is working as expected for HTTP.

### Using SSH

```sh
> echo "git@github.com:Azure/azure-saas.git" | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/'

git@github.com:Azure/azure-saas.git
```

### Using HTTP

```sh
> echo "https://github.com/Azure/azure-saas.git" | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/'

Azure/azure-saas
```

## With this change

Note that the result with HTTP doesn't change, and that now the results with SSH is the same as with HTTP.

### Using SSH

```sh
> echo "git@github.com:Azure/azure-saas.git" | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/' | sed 's/.*:\(.*\)\.git/\1/'

Azure/azure-saas
```

### Using HTTP

```sh
> echo "https://github.com/Azure/azure-saas.git" | sed 's/.*\/\([^ ]*\/[^.]*\).*/\1/' | sed 's/.*:\(.*\)\.git/\1/'

Azure/azure-saas
```

## Conclusion

This second `sed` command has no effect on HTTP urls, as it just removes the content that is before the `:` and the trailing `.git`, but it ensures that if the repo was cloned using SSH, the value of `git_org_project_name` will be the same as it was cloned using HTTP.

This solves the issue #265.